### PR TITLE
Add support for JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ Localized.ready(function(){
 The `localized.js` script exposes a number of functions:
 
 * `ready` - a function that initializes the strings (i.e., downloads) on the client-side. A callback
-should be passed, as well as any desired options, which include `noCache` (whether to do cache busting, default is no)
-and `url` (the url end-point to use to call `getStrings` -- see above, default is '/strings/').  If the `url`
+should be passed, as well as any desired options, which include `noCache` (whether to do cache busting, default is no),
+`isFile` (if '.json' should be appended to the end of the URL, default is false), and `url`
+(the url end-point to use to call `getStrings` -- see above, default is '/strings/').  If the `url`
 is an absolute URL beginning in "http", the URL will not be processed in any way.  Otherwise, URLs get
 extra langauge info added (e.g., `/strings/[lang]`) based on what is in the HTML element's lang attribute.
 
@@ -182,6 +183,11 @@ var options = { noCache: true, url: '/localized' }
 localized.ready(options, readyCallback);
 // NOTE: you could also call it like so:
 // localized.ready(function(){...}); with no options.
+
+// Request the JSON file directly instead of requesting JSON from an API
+// (eg: if language is 'en-US', file name would be 'en-US.json')
+var options = { isFile: true }
+localized.ready(options, readyCallback);
 ```
 
 * `getCurrentLang` - a function that returns the current language defined in the HTML element of the page.

--- a/localized.js
+++ b/localized.js
@@ -78,6 +78,7 @@
       }
 
       var noCache = !!options.noCache,
+          isFile = !!options.isFile,
           url = options.url || '/strings';
 
       // If given an absolute url (starting in http), we don't process it.
@@ -85,6 +86,9 @@
       if (url.indexOf( 'http' ) !== 0) {
         url = url.replace(/^\/?/, '/').replace(/\/?$/, '/');
         url = url + getCurrentLang();
+        if (isFile) {
+          url = url + '.json';
+        }
       }
 
       // Add cache busting if requested.


### PR DESCRIPTION
Currently, this module assumes that when used client-side, the JSON file will be served by some kind of node route. This isn't currently the case on webmaker-profile; we're going to pull the JSON directly, and this lets me do that!

https://bugzilla.mozilla.org/show_bug.cgi?id=912642
