### PR TITLE
Add global var for requirejs case

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ require(['path/to/localized'], function(localized) {
 });
 ```
 
+### Forcing Localized on the Global
+
+In some cases, it might be desirable to have the `localized` object placed on the global (e.g., `window`) even though requirejs is present in the page. This can be accomplished by assigning `true` to `window.__LOCALIZED_IGNORE_REQUIREJS`.
+
 ### Global Usage
 
 If you aren't using an AMD loader like require.js, the object will get added to the global:

--- a/localized.js
+++ b/localized.js
@@ -1,6 +1,11 @@
 (function(global, factory) {
-  // AMD. Register as an anonymous module.
-  if (typeof define === 'function' && define.amd) {
+  // AMD. Register as an anonymous module. Also deal with the case
+  // that we've been told to force localized on the global (e.g.,
+  // in cases where require.js might exist in a page and we want to
+  // ignore it and use the global instead).
+  if (typeof define === 'function' &&
+      define.amd                   &&
+      !__LOCALIZED_IGNORE_REQUIREJS) {
     define(factory);
   }
   // Expose a global instead


### PR DESCRIPTION
Modify localized.js to handle the case where some sites have require.js and the object is not being added globally.
