### PR TITLE
New API langToMomentJSLang

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ var languageName = languageNameFor('th-TH');
 // The above will return "ไทย"
 ```
 
+### langToMomentJSLang
+
+The `langToMomentJSLang` function converts the given language name to the [moment.js supported language name](momentLang.js)
+
+```javascript
+var momentJSLang = langToMomentJSLang('en-US');
+// The above will return "en"
+
+var momentJSLang = langToMomentJSLang('th-TH');
+// The above will return "th"
+
+var momentJSLang = langToMomentJSLang('en-CA');
+// The above will return "en-ca"
+```
+
 ## Client-Side in the browser
 
 Install the browser `localized.js` script using bower:
@@ -237,6 +252,20 @@ localized.ready(options, readyCallback);
 ...
 </script>
 ```
+
+* `langToMomentJSLang` - a function that converts the given language name to the [moment.js supported language name](momentLang.js)
+
+```javascript
+var momentJSLang = langToMomentJSLang('en-US');
+// The above will return "en"
+
+var momentJSLang = langToMomentJSLang('th-TH');
+// The above will return "th"
+
+var momentJSLang = langToMomentJSLang('en-CA');
+// The above will return "en-ca"
+```
+
 
 * `get` - a function that gets the localized version of a given string key. Must be called after `ready` has completed so that
 the localized strings are loaded.

--- a/i18n.js
+++ b/i18n.js
@@ -5,8 +5,8 @@
 var fs = require('fs'),
     path = require('path'),
     util = require('util'),
-    langMap = require("./langmap");
-
+    langMap = require("./langmap"),
+    momentLang = require("./momentLang");
 
 var BIDI_RTL_LANGS = ['ar', 'fa', 'he'],
     translations = {},
@@ -29,6 +29,24 @@ function qualityCmp(a, b) {
   } else {
     return -1;
   }
+}
+
+/**
+ * Convert the given language name into Moment.js supported Language name
+ *
+ *   lang: 'en-US' return: 'en'
+ *   lang: 'en-CA' return: 'en-ca'
+ *   lang: 'th-TH' return: 'th'
+ **/
+function langToMomentJSLang(lang) {
+  lang = lang.toLowerCase();
+  var newLang = lang.substr(0,2);
+  if (momentLang.map.indexOf(lang) !== -1) {
+   return lang;
+  } else if (momentLang.map.indexOf(newLang) !== -1) {
+   return newLang;
+  }
+  return 'en';
 }
 
 /**
@@ -341,6 +359,8 @@ exports.middleware = function(options) {
     }
     locals.languageNameFor = languageNameFor;
     req.languageNameFor = languageNameFor;
+    locals.langToMomentJSLang = langToMomentJSLang;
+    req.langToMomentJSLang = langToMomentJSLang;
     locals.gettext = gt;
     req.gettext = gt;
 

--- a/localized.js
+++ b/localized.js
@@ -62,6 +62,35 @@
     },
 
     /**
+     * Convert the given language name into Moment.js supported Language name
+     *
+     *   lang: 'en-US' return: 'en'
+     *   lang: 'en-CA' return: 'en-ca'
+     *   lang: 'th-TH' return: 'th'
+     **/
+    langToMomentJSLang: function(lang) {
+      /* The list of moment.js supported languages
+       * Extracted from https://rawgithub.com/moment/moment/2.2.1/min/moment+langs.js
+       */
+      var momentLangMap = ['en', 'ar-ma', 'ar', 'bg', 'br', 'ca', 'cs', 'cv',
+             'da', 'de', 'el', 'en-ca', 'en-gb', 'eo', 'es', 'et',
+             'eu', 'fa','fi','fr-ca','fr','gl','he','hi','hr','hu',
+             'id', 'is', 'it', 'ja', 'ka', 'ko', 'lv', 'ml', 'mr',
+             'ms-my','nb','ne','nl','nn','pl','pt-br','pt','ro',
+             'ru', 'sk', 'sl', 'sq', 'sv', 'th', 'tr', 'tzm-la',
+             'tzm', 'uk', 'zh-cn', 'zh-tw'];
+
+      lang = lang.toLowerCase();
+      var newLang = lang.substr(0,2);
+      if (momentLangMap.indexOf(lang) !== -1) {
+        return lang;
+      } else if (momentLangMap.indexOf(newLang) !== -1) {
+        return newLang;
+      }
+      return 'en';
+    },
+
+    /**
      * gets the current lang used for the given page, or en-US by default.
      */
     getCurrentLang: getCurrentLang,

--- a/momentLang.js
+++ b/momentLang.js
@@ -1,0 +1,12 @@
+/* The list of moment.js supported languages
+ * Extracted from https://rawgithub.com/moment/moment/2.2.1/min/moment+langs.js
+ */
+module.exports = {
+  map: ['en', 'ar-ma', 'ar', 'bg', 'br', 'ca', 'cs', 'cv',
+        'da', 'de', 'el', 'en-ca', 'en-gb', 'eo', 'es', 'et',
+        'eu', 'fa','fi','fr-ca','fr','gl','he','hi','hr','hu',
+        'id', 'is', 'it', 'ja', 'ka', 'ko', 'lv', 'ml', 'mr',
+        'ms-my','nb','ne','nl','nn','pl','pt-br','pt','ro',
+        'ru', 'sk', 'sl', 'sq', 'sv', 'th', 'tr', 'tzm-la',
+        'tzm', 'uk', 'zh-cn', 'zh-tw'];
+};


### PR DESCRIPTION
This function langToMomentJSLang() will allow us to convert the given
language name to a supported moment.js language name
e.g. `en-CA` to `en-ca` - or `th-TH` to `th`
