### PR TITLE
Convert all the request for the mapping to one

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -333,7 +333,7 @@ exports.middleware = function(options) {
         locals = {},
         gt;
 
-    lang = substituteMapping(lang);
+    lang = substituteMapping(languageFrom(lang));
 
     // BIDI support, which direction does text flow?
     lang_dir = BIDI_RTL_LANGS.indexOf(lang) >= 0 ? 'rtl' : 'ltr';


### PR DESCRIPTION
So if the request come as `en-ca` or `en-CA` it will work for both
Currently if we set the mapping `"en-CA": "en-US"` it will only work for that case letter
this will allow us to get it work for both
