### PR TITLE
Bug 951390 - Options in middleware setup should not allow empty

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -243,7 +243,9 @@ exports.stringsRoute = function(defaultLang) {
  * headers or URLs, and provides `gettext` and `format` to other middleware functions.
  */
 exports.middleware = function(options) {
-  options = options || {};
+  if (!options) {
+    throw new Error("No options passed in the middleware function. Please see the README for more info.");
+  }
   options.translation_directory = options.translation_directory || 'locale/';
   options.mappings = options.mappings || {};
 

--- a/test/test.js
+++ b/test/test.js
@@ -57,7 +57,7 @@ describe("Middleware setup", function (){
 		});
 	});
 	describe("with bad invocation of the middleware", function(done) {
-		it.skip("should throw an error when no option passed", function(){
+		it("should throw an error when no option passed", function(){
 			should(function (){
 				i18n.middleware();
 			}).throw();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=951390
